### PR TITLE
Post detail

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+. ./env/bin/activate
+set -o allexport; source ~/code/website/.env; set +o allexport
+cd website/

--- a/website/blog/models.py
+++ b/website/blog/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.urls import reverse
+from django.template.defaultfilters import slugify
 from markdownx.models import MarkdownxField
 
 
@@ -20,7 +21,11 @@ class Post(models.Model):
         return self.title
 
     def get_absolute_url(self):
-        return reverse("post-list")
+        return reverse("post-view", self.slug)
+
+    def save(self, *args, **kwargs):
+        self.slug = slugify(self.title)
+        super(Post, self).save(*args, **kwargs)
 
 
 class Category(models.Model):

--- a/website/blog/urls.py
+++ b/website/blog/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from blog.views import PostListView, PostCreateView
+from blog.views import PostListView, PostCreateView, PostDetailView
 
 
 urlpatterns = [
     path("", PostListView.as_view(), name="post-list"),
     path("create", PostCreateView.as_view(), name="post-create"),
+    path("<slug:blog_slug>/", PostDetailView.as_view(), name="post-view"),
 ]

--- a/website/blog/views.py
+++ b/website/blog/views.py
@@ -1,5 +1,6 @@
 from django.views.generic.list import ListView
 from django.views.generic.edit import CreateView
+from django.views.generic.detail import DetailView
 from blog.models import Post
 from blog.forms import PostForm
 
@@ -16,3 +17,9 @@ class PostListView(ListView):
 class PostCreateView(CreateView):
     model = Post
     fields = ["title", "body", "category"]
+
+
+class PostDetailView(DetailView):
+    model = Post
+    slug_url_kwarg = "blog_slug"
+    slug_field = "slug"

--- a/website/templates/blog/post_detail.html
+++ b/website/templates/blog/post_detail.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %} 
+ 
+{% block content %}
+   {{ post.title }}
+   {{ post.body }}
+{% endblock content %}

--- a/website/templates/blog/post_list.html
+++ b/website/templates/blog/post_list.html
@@ -4,7 +4,7 @@
    <h1>Posts</h1>
     <ul>
     {% for post in object_list %}
-        <li>{{ post.title }}</li>
+        <li><a href="{% url 'post-view' post.slug %}">{{ post.title }}</a></li>
     {% empty %}
         <li>No articles yet.</li>
     {% endfor %}

--- a/website/tests/test_blog/unit/test_views.py
+++ b/website/tests/test_blog/unit/test_views.py
@@ -13,10 +13,14 @@ def create_category():
 
     def _make_create_category(title):
         category = Category(title=title)
+        category.save()
         created_categories.append(category)
         return category
 
     yield _make_create_category
+
+    for category in created_categories:
+        category.delete()
 
 
 @pytest.fixture
@@ -26,10 +30,14 @@ def create_post():
 
     def _make_create_post(title, body, category):
         post = Post(title=title, body=body, category=category)
+        post.save()
         created_posts.append(post)
         return post
 
     yield _make_create_post
+
+    for post in created_posts:
+        post.delete()
 
 
 def test_blog_app():
@@ -50,11 +58,33 @@ def test_create_status(client):
 
 
 @pytest.mark.django_db
-def test_create_post(create_category, create_post):
-    category = create_category("Test")
-    assert isinstance(category, Category)
-    assert category.title == "Test"
-    post = create_post("Test 1", "# Here is a body title", category)
-    assert isinstance(post, Post)
-    assert post.title == "Test 1"
-    assert markdown.markdown(post.body) == "<h1>Here is a body title</h1>"
+@pytest.mark.parametrize("category_title", ["test", "test_category"])
+@pytest.mark.parametrize(
+    "post_title,post_body,post_body_md",
+    [
+        ("test", "# Here is a body title", "<h1>Here is a body title</h1>"),
+        (
+            "test_post",
+            "**Here is a body title**",
+            "<p><strong>Here is a body title</strong></p>",
+        ),
+    ],
+)
+def test_detail_status(
+    client,
+    create_category,
+    create_post,
+    category_title,
+    post_title,
+    post_body,
+    post_body_md,
+):
+    response = client.get(reverse("post-view", args=[post_title]))
+    assert response.status_code == 404
+    category = create_category(category_title)
+    assert str(category) == category_title
+    post = create_post(post_title, post_body, category)
+    assert str(post) == post_title
+    assert markdown.markdown(post.body) == post_body_md
+    response = client.get(reverse("post-view", args=[post.slug]))
+    assert response.status_code == 200


### PR DESCRIPTION
# Task
Add a post detail view and template to enable the viewing of posts
# Expected Result
Able to click on an added post on the index page and see the contents of the post object on it's own separate page with the url slug
# Result
As above, with added functionality for automated testing