### PR TITLE
Add verbose_name_plural meta field to blog.Category model.

### DIFF
--- a/website/blog/models.py
+++ b/website/blog/models.py
@@ -32,6 +32,9 @@ class Category(models.Model):
     title = models.CharField(max_length=100, db_index=True)
     slug = models.SlugField(max_length=100, db_index=True)
 
+    class Meta:
+        verbose_name_plural = "categories"
+
     def __str__(self):
         return self.title
 


### PR DESCRIPTION
# Task
Fix plural of 'Category' in the admin interface (originally 'Categorys')
# Expected Result
The title says 'Categories'
# Result
As expected.